### PR TITLE
Ensure usage of bash

### DIFF
--- a/lambda_package/build_package.sh
+++ b/lambda_package/build_package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -Eeuo pipefail
 


### PR DESCRIPTION
`sh` must not be an alias to `bash` on GH runners